### PR TITLE
Fix cross-platform build issues and atomic init

### DIFF
--- a/CentralCache.cpp
+++ b/CentralCache.cpp
@@ -1,5 +1,6 @@
 #include "CentralCache.h"
 #include "PageCache.h"
+#include <thread>
 
 void* CentralCache::getCentralCache(size_t index) {
     if(index > MaxIndex) {

--- a/CentralCache.h
+++ b/CentralCache.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "helper.h"
 #include <mutex>
+#include <atomic>
 class CentralCache {
 public:
     static CentralCache* get() {
@@ -14,8 +15,10 @@ private:
     CentralCache() {
         for (auto& slot : CentralFreeList) {
             slot.store(nullptr, std::memory_order_relaxed);
-        }        
-        CentralFreeListLock.fill(std::atomic_flag{});
+        }
+        for (auto& flag : CentralFreeListLock) {
+            flag.clear();
+        }
     }
 
     void* getPageCache(size_t size);

--- a/helper.h
+++ b/helper.h
@@ -1,6 +1,12 @@
+#pragma once
 #include <stdexcept>
 #include <array>
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <stdlib.h>
+#include <sys/mman.h>
+#endif
 
 constexpr size_t MaxSize = 256 * 1024; // 256 KB
 constexpr size_t alignment = sizeof(void*);
@@ -8,10 +14,33 @@ constexpr size_t MaxIndex = MaxSize / alignment;
 constexpr size_t SpanPage = 8;
 constexpr size_t PageSize = 4096;
 
-size_t getIndex(size_t size){
+inline size_t getIndex(size_t size){
     if(size <= 0){
         throw std::invalid_argument("Size must be greater than 0");
     }
 
     return (size - 1) / alignment;
 }
+
+#ifndef _WIN32
+#ifndef MEM_COMMIT
+#define MEM_COMMIT 0
+#endif
+#ifndef MEM_RESERVE
+#define MEM_RESERVE 0
+#endif
+#ifndef MEM_RELEASE
+#define MEM_RELEASE 0
+#endif
+#ifndef PAGE_READWRITE
+#define PAGE_READWRITE 0
+#endif
+inline void* VirtualAlloc(void* addr, size_t size, int, int) {
+    void* ptr = aligned_alloc(PageSize, size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+inline void VirtualFree(void* addr, size_t, int) {
+    free(addr);
+}
+#endif


### PR DESCRIPTION
## Summary
- add `#pragma once` and cross-platform memory functions in `helper.h`
- initialize `CentralCache` flags correctly and include `<atomic>`
- include `<thread>` for `std::this_thread::yield`

## Testing
- `g++ -std=c++17 -O2 -pthread test.cpp CentralCache.cpp MemoryPool.cpp PageCache.cpp ThreadCache.cpp MemoryBucket.cpp -o test`
- `./test`

------
https://chatgpt.com/codex/tasks/task_e_688b9ee7de40832584995e118f0b3d9a