### PR TITLE
Fix ThreadCache free-list trimming logic

### DIFF
--- a/ThreadCache.cpp
+++ b/ThreadCache.cpp
@@ -45,13 +45,13 @@ void ThreadCache::returnCentralCache(void* ptr, size_t size){
     size_t keptNum = totalNum / 4;
     
     void* end = ptr;
-    for(size_t i = 0; i < keptNum; ++i){
+    for (size_t i = 1; i < keptNum; ++i) {
         end = *reinterpret_cast<void**>(end);
     }
 
     void* returnPtr = *reinterpret_cast<void**>(end);
     *reinterpret_cast<void**>(end) = nullptr;
-    freeList[index] = end;
+    freeList[index] = ptr;
     freeListSize[index] = keptNum;
     if(returnPtr){
         // Return the rest of the memory to the central cache


### PR DESCRIPTION
## Summary
- correct traversal logic when trimming the ThreadCache free-list
- keep the first `keptNum` nodes and release the rest

## Testing
- `g++ -std=c++11 -pthread CentralCache.cpp MemoryPool.cpp PageCache.cpp ThreadCache.cpp MemoryBucket.cpp test.cpp -o test && echo "build success"`

------
https://chatgpt.com/codex/tasks/task_e_688ba26778b883258a529d926ed3eaf9